### PR TITLE
Create Docker Image to run UV Chromatogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+docker/uv_chromatogram.py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM mono:5.20.1.34
+
+RUN apt-get update
+RUN apt-get install -y python3 python3-pip clang curl libglib2.0-dev
+RUN python3 --version
+RUN pip3 --version
+RUN pip3 install pycparser==2.17
+RUN pip3 install pythonnet==2.4.0
+RUN pip3 install numpy
+RUN pip3 install ms_deisotope
+
+COPY uv_chromatogram.py /root/uv_chromatogram.py

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,17 @@
+# Docker Image to run UV Chromatogram
+
+Build the image:
+
+```
+$ ./build
+```
+
+Run the image:
+
+```
+docker run \
+  -v /path/to/directory/raw:/raw \
+  -v /path/to/directory/output:/output \
+  -it docker-uv-chromatogram-extraction \
+  python3 /root/uv_chromatogram.py /raw/filename.raw /output/output.csv
+```

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cp ../uv_chromatogram.py .
+docker build --tag docker-uv-chromatogram-extraction  .
+rm uv_chromatogram.py

--- a/uv_chromatogram.py
+++ b/uv_chromatogram.py
@@ -76,7 +76,7 @@ def load_chromatogram(raw_file_reader):
 def main(raw_file_path, output_path):
     raw_file = open_raw(raw_file_path)
     time, intensity = load_chromatogram(raw_file)
-    with open(output_path, 'wb') as fh:
+    with open(output_path, 'w') as fh:
         writer = csv.writer(fh)
         writer.writerow(['time', 'intensity'])
         writer.writerows(zip(time, intensity))


### PR DESCRIPTION
This PR Adds a docker file and supporting scripts to run the UV Chromatogram python script.

Also added a change to write the CSV file without the binary flag, which allows the script to run on python 3.